### PR TITLE
Check active governor and flush STDOUT pipes

### DIFF
--- a/auto-epp
+++ b/auto-epp
@@ -2,6 +2,7 @@
 
 import os
 import time
+import sys
 import configparser
 
 CONFIG_FILE = "/etc/auto-epp.conf"
@@ -16,6 +17,7 @@ def check_root():
         return
     else:                                        
         print("auto-epp must be run with root privileges.")
+        sys.stdout.flush()
         exit(1)
 
 def check_driver():
@@ -29,6 +31,7 @@ def check_driver():
         return
     else:
         print("The system not runing amd-pstate-epp")
+        sys.stdout.flush()
         exit(1)
 
 def read_config():
@@ -86,14 +89,23 @@ def charging():
     return True
 
 def set_governor():
-    cpu_count = os.cpu_count()
-    for cpu in range(cpu_count):
-        governor_file_path = f'/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_governor'
-        try:
-            with open(governor_file_path, 'w') as file:
-                file.write("powersave")
-        except:
-            exit(1)
+    get_governor_file_path = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor'
+    try:
+        # get current governor
+        with open(get_governor_file_path) as gov_file:
+            cur_governor = gov_file.read()[:-1]
+            if cur_governor != "powersave":
+                print(f'Current governor "{cur_governor}" is not "powersave". Setting governor to "powersave"')
+                sys.stdout.flush()
+
+                # setting governor to powersave
+                cpu_count = os.cpu_count()
+                for cpu in range(cpu_count):
+                    governor_file_path = f'/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_governor'
+                    with open(governor_file_path, 'w') as file:
+                        file.write("powersave")
+    except:
+        exit(1)
 
 def set_epp(epp_value):
     cpu_count = os.cpu_count()


### PR DESCRIPTION
1. In function set_governor() add check for current active governor, and perform governor change to "powersave" only if it is not in "powersave" mode. Also print message to log about this.
Motivation: it saves few system calls every 2 seconds, and possibly avoids some unknown problems with epp driver(it can trigger some internal changes even if we changing to the same value?). Print message because by default governor should be in "powersave" mode, and if something changes it constantly we should see this in the logs.

2. Add sys.stdout.flush() call after every print message. Our service's STDOUT and STDERR are pipes, and in this case the buffer is only flushed once it is full. Hence the script's messages only turn up in systemd's logs after it has produced even more output. Alternative is to add "Environment=PYTHONUNBUFFERED=1" to service unit file in [Service] section.